### PR TITLE
Improved HomeKit status characteristics

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -14,6 +14,11 @@
       "password": {
         "title": "Password",
         "type": "string",
+        "format": "password",
+        "x-schema-form": {
+          "type": "password"
+        },
+        "writeOnly": true,
         "required": true,
         "default": ""
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-kidde",
   "displayName": "Homebridge Kidde",
   "type": "module",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "description": "Kidde smart smoke detector",
   "author": "Mikael Sjödin",
@@ -20,7 +20,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": "^18.20.4 || ^20.18.0 || ^22.10.0",
+    "node": "^18.20.4 || ^20.18.0 || ^22.10.0 || ^24.0.0",
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "rimraf ./dist && tsc",
     "lint": "eslint . --max-warnings=0",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run build",
     "watch": "npm run build && npm link && nodemon",
     "test": "jest",

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -9,6 +9,7 @@ export class KiddeSmokeCOAlarm {
   private smokeService : Service | undefined;
   private temperatureService : Service | undefined;
   private batteryService : Service | undefined;
+  private loggedUnexpectedEndOfLifeStatus = false;
   constructor(protected platform: KiddeHomebridgePlatform,
         protected client: KiddeClient,
         protected device_id: number,
@@ -37,11 +38,19 @@ export class KiddeSmokeCOAlarm {
       this.accessory.addService(this.platform.Service.Battery);
       this.batteryService.getCharacteristic(this.platform.Characteristic.StatusLowBattery)
         .onGet(this.handleBatteryGet.bind(this));
+      this.batteryService.getCharacteristic(this.platform.Characteristic.BatteryLevel)
+        .onGet(this.handleBatteryLevelGet.bind(this));
+      this.batteryService.getCharacteristic(this.platform.Characteristic.ChargingState)
+        .updateValue(this.platform.Characteristic.ChargingState.NOT_CHARGEABLE);
       if ((this.client.devices![this.device_id].cap_sensor as Array<string>).includes('CO')) {
         this.coService = this.accessory.getService(this.platform.Service.CarbonMonoxideSensor) ||
           this.accessory.addService(this.platform.Service.CarbonMonoxideSensor);
         this.coService.getCharacteristic(this.platform.Characteristic.CarbonMonoxideDetected)
           .onGet(this.handleCarbonMonoxideDetectedGet.bind(this));
+        this.coService.getCharacteristic(this.platform.Characteristic.StatusActive)
+          .onGet(this.handleStatusActiveGet.bind(this));
+        this.coService.getCharacteristic(this.platform.Characteristic.StatusFault)
+          .onGet(this.handleStatusFaultGet.bind(this));
       }
 
       if ((this.client.devices![this.device_id].cap_sensor as Array<string>).includes('Smoke')) {
@@ -49,6 +58,10 @@ export class KiddeSmokeCOAlarm {
           this.accessory.addService(this.platform.Service.SmokeSensor);
         this.smokeService.getCharacteristic(this.platform.Characteristic.SmokeDetected)
           .onGet(this.handleSmokeDetectedGet.bind(this));
+        this.smokeService.getCharacteristic(this.platform.Characteristic.StatusActive)
+          .onGet(this.handleStatusActiveGet.bind(this));
+        this.smokeService.getCharacteristic(this.platform.Characteristic.StatusFault)
+          .onGet(this.handleStatusFaultGet.bind(this));
       }
 
       if ((this.client.devices![this.device_id].capabilities as Array<string>).includes('temperature')) {
@@ -57,6 +70,7 @@ export class KiddeSmokeCOAlarm {
         this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
           .onGet(this.handleTemperatureGet.bind(this));
       }
+      this.logUnexpectedEndOfLifeStatus(this.client.devices![this.device_id]);
   }
 
   private update(oldData: Record<number, Record<string, unknown>> | undefined, newData: Record<number, Record<string, unknown>>) {
@@ -69,11 +83,16 @@ export class KiddeSmokeCOAlarm {
       oldData![this.device_id].battery_state !== newData![this.device_id].battery_state) {
       this.batteryService.updateCharacteristic(this.platform.Characteristic.StatusLowBattery,
         this.convertBattery(newData![this.device_id].battery_state as string));
+      this.batteryService.updateCharacteristic(this.platform.Characteristic.BatteryLevel,
+        this.convertBatteryLevel(newData![this.device_id].battery_state as string));
     }
     if (this.coService && oldData &&
         oldData![this.device_id].co_alarm !== newData![this.device_id].co_alarm) {
       this.coService.updateCharacteristic(this.platform.Characteristic.CarbonMonoxideDetected,
         this.convertCarbonMonoxideDetected(newData![this.device_id].co_alarm as boolean));
+    }
+    if (this.coService && oldData && this.didStatusFaultStateChange(oldData![this.device_id], newData![this.device_id])) {
+      this.updateStatusCharacteristics(this.coService, newData![this.device_id]);
     }
     if (this.humidityService && oldData &&
         (oldData![this.device_id].humidity as {value: number}).value !== (newData![this.device_id].humidity as {value: number}).value) {
@@ -84,6 +103,9 @@ export class KiddeSmokeCOAlarm {
         oldData![this.device_id].smoke_alarm !== newData![this.device_id].smoke_alarm) {
       this.smokeService.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
         this.convertSmokeDetected(newData![this.device_id].smoke_alarm as boolean));
+    }
+    if (this.smokeService && oldData && this.didStatusFaultStateChange(oldData![this.device_id], newData![this.device_id])) {
+      this.updateStatusCharacteristics(this.smokeService, newData![this.device_id]);
     }
     if (this.temperatureService && oldData && 
       (oldData![this.device_id].iaq_temperature as {value: number}).value !== (newData![this.device_id].iaq_temperature as {value: number}).value) {
@@ -101,6 +123,7 @@ export class KiddeSmokeCOAlarm {
       this.airQualityService.updateCharacteristic(this.platform.Characteristic.VOCDensity,
         this.convertVoc((newData![this.device_id].tvoc as {value: number}).value));
     }
+    this.logUnexpectedEndOfLifeStatus(newData![this.device_id]);
   }
 
   async handleAirQualityGet(): Promise<CharacteristicValue> {
@@ -140,6 +163,66 @@ export class KiddeSmokeCOAlarm {
       return this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
     }
     return this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW;
+  }
+
+  async handleBatteryLevelGet(): Promise<CharacteristicValue> {
+    return this.convertBatteryLevel(this.client.devices![this.device_id].battery_state as string);
+  }
+
+  private convertBatteryLevel(battery_state: string) : CharacteristicValue {
+    if (battery_state === 'ok') {
+      return 100;
+    }
+    return 10;
+  }
+
+  async handleStatusActiveGet(): Promise<CharacteristicValue> {
+    return this.isDeviceActive(this.client.devices![this.device_id]);
+  }
+
+  async handleStatusFaultGet(): Promise<CharacteristicValue> {
+    return this.convertStatusFault(this.client.devices![this.device_id]);
+  }
+
+  private didStatusFaultStateChange(oldDevice: Record<string, unknown>, newDevice: Record<string, unknown>) {
+    return oldDevice.offline !== newDevice.offline ||
+      oldDevice.lost !== newDevice.lost ||
+      oldDevice.contact_lost !== newDevice.contact_lost ||
+      oldDevice.life !== newDevice.life ||
+      oldDevice.end_of_life_status !== newDevice.end_of_life_status;
+  }
+
+  private updateStatusCharacteristics(service: Service, device: Record<string, unknown>) {
+    service.updateCharacteristic(this.platform.Characteristic.StatusActive, this.isDeviceActive(device));
+    service.updateCharacteristic(this.platform.Characteristic.StatusFault, this.convertStatusFault(device));
+  }
+
+  private isDeviceActive(device: Record<string, unknown>) : CharacteristicValue {
+    return !this.hasConnectionFault(device);
+  }
+
+  private convertStatusFault(device: Record<string, unknown>) : CharacteristicValue {
+    if (this.hasConnectionFault(device) || this.isEndOfLife(device)) {
+      return this.platform.Characteristic.StatusFault.GENERAL_FAULT;
+    }
+    return this.platform.Characteristic.StatusFault.NO_FAULT;
+  }
+
+  private hasConnectionFault(device: Record<string, unknown>) {
+    return device.offline === true || device.lost === true || device.contact_lost === true;
+  }
+
+  private isEndOfLife(device: Record<string, unknown>) {
+    return typeof device.life === 'number' && device.life <= 0;
+  }
+
+  private logUnexpectedEndOfLifeStatus(device: Record<string, unknown>) {
+    if (this.loggedUnexpectedEndOfLifeStatus || device.end_of_life_status === undefined || device.end_of_life_status === 1) {
+      return;
+    }
+    this.loggedUnexpectedEndOfLifeStatus = true;
+    this.platform.log.warn('Kidde device returned unexpected end_of_life_status for',
+      this.accessory.displayName, device.end_of_life_status);
   }
   
   async handleCarbonMonoxideDetectedGet(): Promise<CharacteristicValue> {


### PR DESCRIPTION
Hello,

First off, I would like to thank you for your plugin. It's been awesome to have my Kidde smoke detector in Apple Home.

I am running this successfully with Homebridge 2.0.2 and Node.js 24.15.0 against a Kidde smoke/CO alarm.

Summary of what’s in the branch:

  - Node 24 engine support
  - Password masking in Homebridge UI schema
  - Battery level + not-chargeable charging state
  - StatusActive / StatusFault for smoke and CO services
  - Fault handling for offline/lost/contact-lost/end-of-life states

  I verified lint, tests, and build before pushing.

Would you be open to a PR for these changes?

I can split it into smaller PRs if preferred:

1. Node 24 + UI schema password masking
2. Battery service improvements
3. Smoke/CO status fault handling

Please let me know.

Thank you,
snaket7ds